### PR TITLE
Add privacy policy page for church_app Apple App Store submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
       "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -265,6 +266,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
       "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.6",
         "@firebase/component": "0.7.0",
@@ -280,7 +282,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.2",
@@ -731,6 +734,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1272,6 +1276,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1703,6 +1708,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2131,6 +2137,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -2831,6 +2838,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2999,6 +3007,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5243,6 +5252,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5419,6 +5429,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5431,6 +5442,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6389,6 +6401,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6558,6 +6571,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+    title: "Privacy Policy - Vietnamese Evangelical Church of North Carolina",
+    description: "Privacy Policy for the Vietnamese Evangelical Church of North Carolina mobile application",
+};
+
+export default function PrivacyPolicy() {
+    return (
+        <main className="min-h-screen bg-gray-50">
+            <div className="max-w-3xl mx-auto px-6 py-16">
+                <h1 className="text-3xl font-bold text-gray-900 mb-2">Privacy Policy</h1>
+                <p className="text-gray-600 mb-8">Last updated: January 19, 2026</p>
+
+                <div className="bg-white rounded-xl shadow-sm p-8 space-y-8">
+                    {/* Introduction */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Introduction</h2>
+                        <p className="text-gray-700 leading-relaxed">
+                            Vietnamese Evangelical Church of North Carolina (&quot;we,&quot; &quot;our,&quot; or &quot;us&quot;) operates the
+                            Vietnamese Evangelical Church mobile application (the &quot;App&quot;). This Privacy Policy explains how we
+                            handle information when you use our App.
+                        </p>
+                    </section>
+
+                    {/* Information Collection */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Information We Collect</h2>
+                        <p className="text-gray-700 leading-relaxed mb-4">
+                            Our App is designed for content consumption only. <strong>We do not collect, store, or process
+                                any personal information from our users.</strong> You are not required to create an account or
+                            provide any personal details to use the App.
+                        </p>
+                        <p className="text-gray-700 leading-relaxed">
+                            The App does not collect:
+                        </p>
+                        <ul className="list-disc list-inside text-gray-700 mt-2 space-y-1 ml-4">
+                            <li>Names, email addresses, or contact information</li>
+                            <li>Location data</li>
+                            <li>Payment or financial information</li>
+                            <li>User-generated content</li>
+                        </ul>
+                    </section>
+
+                    {/* Third-Party Services */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Third-Party Services</h2>
+                        <p className="text-gray-700 leading-relaxed mb-4">
+                            Our App uses the following third-party services to deliver content:
+                        </p>
+                        <ul className="list-disc list-inside text-gray-700 space-y-2 ml-4">
+                            <li>
+                                <strong>Firebase (Google)</strong> — Used to store and deliver church content such as events
+                                and announcements. Firebase may collect technical information such as device type, operating
+                                system version, and app usage data for service improvement and analytics purposes. For more
+                                information, please review{" "}
+                                <a
+                                    href="https://firebase.google.com/support/privacy"
+                                    className="text-orange-600 hover:underline"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    Firebase&apos;s Privacy Policy
+                                </a>.
+                            </li>
+                        </ul>
+                    </section>
+
+                    {/* Data Storage */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Local Data Storage</h2>
+                        <p className="text-gray-700 leading-relaxed">
+                            The App may cache images and content locally on your device to improve performance and enable
+                            offline viewing. This data is stored only on your device and is not transmitted to us. You can
+                            clear this cached data at any time through your device&apos;s settings.
+                        </p>
+                    </section>
+
+                    {/* Children's Privacy */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Children&apos;s Privacy</h2>
+                        <p className="text-gray-700 leading-relaxed">
+                            Our App does not knowingly collect personal information from children under 13 years of age.
+                            Since our App does not collect any personal information from any users, it is safe for use by
+                            individuals of all ages.
+                        </p>
+                    </section>
+
+                    {/* Data Security */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Data Security</h2>
+                        <p className="text-gray-700 leading-relaxed">
+                            While we do not collect personal information, we take reasonable measures to ensure that the
+                            content delivered through our App is transmitted securely using industry-standard encryption
+                            (HTTPS/TLS).
+                        </p>
+                    </section>
+
+                    {/* Changes */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Changes to This Privacy Policy</h2>
+                        <p className="text-gray-700 leading-relaxed">
+                            We may update this Privacy Policy from time to time. Any changes will be posted on this page
+                            with an updated &quot;Last updated&quot; date. We encourage you to review this Privacy Policy periodically.
+                        </p>
+                    </section>
+
+                    {/* Contact */}
+                    <section>
+                        <h2 className="text-xl font-semibold text-gray-900 mb-3">Contact Us</h2>
+                        <p className="text-gray-700 leading-relaxed">
+                            If you have any questions about this Privacy Policy or our practices, please contact us at:
+                        </p>
+                        <div className="mt-4 p-4 bg-gray-50 rounded-lg">
+                            <p className="text-gray-900 font-medium">Vietnamese Evangelical Church of North Carolina</p>
+                            <p className="text-gray-700">
+                                Email:{" "}
+                                <a
+                                    href="mailto:loc.software.dev@gmail.com"
+                                    className="text-orange-600 hover:underline"
+                                >
+                                    loc.software.dev@gmail.com
+                                </a>
+                            </p>
+                        </div>
+                    </section>
+                </div>
+
+                {/* Footer */}
+                <p className="text-center text-gray-500 text-sm mt-8">
+                    © 2026 Vietnamese Evangelical Church of North Carolina. All rights reserved.
+                </p>
+            </div>
+        </main>
+    );
+}


### PR DESCRIPTION
Created privacy page to have URL for church_app Apple App Store submission.

## Changes
- Added `/privacy` route with Apple-compliant privacy policy language
- Includes disclosure that no personal data is collected (content-only app)
- Third-party service disclosure (Firebase)
- Contact information: loc.software.dev@gmail.com

## URL
Once deployed, the privacy policy will be accessible at: https://vietcorner.org/privacy